### PR TITLE
salmon statistics support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,8 @@ dependencies = [
  "log",
  "minify-html-onepass",
  "proptest",
+ "rand",
+ "rand_distr",
  "reqwest",
  "rocket",
  "serde",
@@ -1023,6 +1025,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f98a04dce437184842841303488f70d0188c5f51437d2a834dc097eafa909a01"
 
 [[package]]
+name = "libm"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
+
+[[package]]
 name = "lock_api"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1238,6 +1246,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1477,6 +1486,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "964d548f8e7d12e102ef183a0de7e98180c9f8729f555897a857b96e48122d2f"
+dependencies = [
+ "num-traits",
+ "rand",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ sled = { version = "0.34", features = ["compression"] }
 twox-hash = "1"
 uuid = { version = "0.8", features = ["serde"] }
 zerocopy = "0.6"
+rand = "0.8.4"
+rand_distr = "0.4.2"
 
 [dev-dependencies]
 float-cmp = "0.9"

--- a/src/chronicler.rs
+++ b/src/chronicler.rs
@@ -105,7 +105,7 @@ pub async fn update_and_load_all<T: DeserializeOwned>(ty: &'static str) -> Resul
 #[derive(Copy, Clone, AsBytes, FromBytes)]
 #[repr(C)]
 pub struct Key {
-    id: [u8; 16],
+    pub id: [u8; 16],
     valid_from: I64<BigEndian>,
 }
 

--- a/src/fraction.rs
+++ b/src/fraction.rs
@@ -7,8 +7,8 @@ use std::ops::{Add, Div, Mul, Sub};
 #[derive(Debug, Clone, Copy)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct Fraction {
-    numer: i64,
-    denom: u64,
+    pub numer: i64,
+    pub denom: u64,
 }
 
 impl Fraction {
@@ -41,7 +41,7 @@ impl Fraction {
         self.numer == i64::MAX && self.denom == u64::MAX
     }
 
-    fn round(self) -> i64 {
+    pub fn round(self) -> i64 {
         assert!(self.denom != 0);
 
         let numer = self.numer.unsigned_abs();

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ static REBUILDING: AtomicBool = AtomicBool::new(false);
 
 // Increment this if you need to force a rebuild.
 const DB_VERSION: &[u8] = &[13];
-const CLEAR_ON_REBUILD: &[&str] = &[summary::TREE, summary::SEASON_TREE];
+const CLEAR_ON_REBUILD: &[&str] = &[summary::TREE, summary::SEASON_TREE, salmon::SUMMARY_TREE];
 const OLD_TREES: &[&str] = &[];
 
 lazy_static::lazy_static! {
@@ -183,6 +183,7 @@ fn rocket() -> _ {
                 routes::tablesort,
                 routes::tablesort_number,
                 routes::team::team,
+                routes::salmon::salmon_page,
             ],
         )
         .attach(AdHoc::on_liftoff("Background tasks", |_rocket| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ const API_BASE: &str = "https://api.blaseball.com";
 const CHRONICLER_BASE: &str = "https://api.sibr.dev/chronicler";
 const CONFIGS_BASE: &str = "https://blaseball-configs.s3.us-west-2.amazonaws.com";
 const SACHET_BASE: &str = "https://api.sibr.dev/eventually/sachet";
-const WEBCRISP_BASE: &str = "http://localhost:9999/api";
+const WEBCRISP_BASE: &str = "https://crisp.sibr.dev/api";
 
 static REBUILDING: AtomicBool = AtomicBool::new(false);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod names;
 mod percentage;
 mod pitching;
 mod routes;
+mod salmon;
 mod schedule;
 mod seasons;
 mod state;

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -2,6 +2,7 @@ pub mod debug;
 pub mod export;
 pub mod game;
 pub mod player;
+pub mod salmon;
 pub mod season;
 pub mod team;
 

--- a/src/routes/salmon.rs
+++ b/src/routes/salmon.rs
@@ -1,0 +1,45 @@
+use crate::chronicler::Key;
+use crate::table::Table;
+use crate::DB;
+use crate::{names, routes::ResponseResult, salmon};
+use anyhow::Result;
+use askama::Template;
+use chrono::Utc;
+use rocket::get;
+use rocket::response::content::Html;
+use uuid::Uuid;
+use zerocopy::AsBytes;
+
+#[get("/salmon/<id>")]
+pub fn salmon_page(id: Uuid) -> ResponseResult<Option<Html<String>>> {
+    Ok(match load_player(id)? {
+        Some(player) => Some(Html(player.render().map_err(anyhow::Error::from)?)),
+        None => None,
+    })
+}
+
+fn load_player(id: Uuid) -> Result<Option<SalmonPage>> {
+    let name = match names::player_name(id)? {
+        Some(name) => name,
+        None => return Ok(None),
+    };
+
+    let salmon_tree = DB.open_tree(salmon::SUMMARY_TREE)?;
+    if let Some((_, summary)) = salmon_tree.get_lt(Key::new(id, Utc::now()).as_bytes())? {
+        Ok(Some(SalmonPage {
+            name,
+            id,
+            salmon: salmon::table(serde_json::from_slice(&summary)?),
+        }))
+    } else {
+        Ok(None)
+    }
+}
+
+#[derive(Template)]
+#[template(path = "salmon.html")]
+struct SalmonPage {
+    name: String,
+    id: Uuid,
+    salmon: Table<{ salmon::COLS }>,
+}

--- a/src/salmon.rs
+++ b/src/salmon.rs
@@ -1,0 +1,261 @@
+// i'm so sorry - allie
+#![allow(dead_code)]
+
+use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand_distr::LogNormal as RngLogNormal;
+
+type LogNormal = RngLogNormal<f64>;
+
+use serde::{Deserialize, Serialize};
+
+static SOULSCREAM_LETTERS: [&'static str; 10] = ["A", "E", "I", "O", "U", "X", "H", "A", "E", "I"];
+
+/// Simplified configuration required for a full CRiSP simulation.
+#[derive(Debug, Default, Serialize)]
+pub struct SalmonConfig {
+    fisheries: Vec<SalmonFishery>,
+    stocks: Vec<SalmonStock>,
+}
+
+/// CRiSP salmon stock parameters.
+#[derive(Debug, Default, Serialize)]
+pub struct SalmonStock {
+    name: &'static str,
+    abbreviation: &'static str,
+    hatchery_n: &'static str,
+    cohort_abundance: [f64; 4],
+    maturation_rate: [f64; 4],
+    adult_equivalent: [f64; 4],
+    maturation_by_year: Vec<[(f64, f64); 4]>,
+    ev_scalars: Vec<f64>,
+    log_p: [&'static str; 6],
+    hatchery_flag: bool,
+    msy_esc: i64,
+    msh_flag: bool,
+    idl: f64,
+    param: f64,
+    age_factor: f64,
+}
+
+/// CRiSP Fishery parameters.
+#[derive(Debug, Default, Serialize)]
+pub struct SalmonFishery {
+    name: &'static str,
+    proportions: [f64; 4],
+    ocean_net: bool,
+    exploitations: Vec<(&'static str, [f64; 4])>,
+    policy: Vec<f64>,
+    terminal: bool,
+}
+
+/// A salmonblall player; stores the minimum subset of information needed to calculate CRiSP simulation parameters and soulscream.
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct SalmonblallPlayer {
+    pub(crate) pressurization: f64,
+    pub(crate) tragicness: f64,
+    pub(crate) shakespearianism: f64,
+    pub(crate) ruthlessness: f64,
+    pub(crate) chasiness: f64,
+    pub(crate) anticapitalism: f64,
+    pub(crate) moxie: f64,
+    pub(crate) divinity: f64,
+    pub(crate) indulgence: f64,
+    pub(crate) buoyancy: f64,
+    pub(crate) watchfulness: f64,
+    pub(crate) soul: i32,
+}
+
+fn stat_soulscream(s: f64, j: f64) -> &'static str {
+    if j * 10.0 == 0.0 {
+        "undefined"
+    } else {
+        SOULSCREAM_LETTERS[((s % j) / j * 10.0).floor() as usize]
+    }
+}
+
+impl SalmonblallPlayer {
+    /// Generates a player's soulscream. Based on the blaseball_mike implementation.
+    pub fn soulscream(&self, byte_limit: Option<usize>) -> String {
+        let mut s = String::new();
+        let byte_limit = byte_limit.unwrap_or(usize::MAX);
+
+        for i in 0..self.soul {
+            if s.len() >= byte_limit {
+                s.truncate(byte_limit);
+                return s;
+            }
+
+            let j = 10f64.powi(-i);
+            let sub_scream = [
+                stat_soulscream(self.pressurization, j),
+                stat_soulscream(self.divinity, j),
+                stat_soulscream(self.tragicness, j),
+                stat_soulscream(self.shakespearianism, j),
+                stat_soulscream(self.ruthlessness, j),
+            ]
+            .concat();
+            s.push_str(&sub_scream);
+            s.push_str(&sub_scream);
+            s.push_str(&sub_scream[0..=0]);
+        }
+
+        s
+    }
+
+    /// Generates n CRiSP simulation parameters, using player stats and an rng seeded by the player's soulscream.
+    pub fn generate_n_simulations(&self, n: usize) -> Vec<SalmonConfig> {
+        let seed: [u8; 32] = {
+            let s = self.soulscream(Some(32));
+            if s.len() < 32 {
+                let remainder = 32 - s.len();
+                s.into_bytes()
+                    .into_iter()
+                    .chain(std::iter::repeat(0).take(remainder))
+                    .collect::<Vec<u8>>()
+                    .try_into()
+                    .unwrap()
+            } else {
+                s.into_bytes().try_into().unwrap()
+            }
+        };
+
+        let mut rng = StdRng::from_seed(seed);
+        std::iter::repeat_with(|| self.generate_crisp_parameters(&mut rng))
+            .take(n)
+            .collect()
+    }
+
+    /// Generates CRiSP simulation parameters using player stats and provided rng. Based on https://github.com/alisww/yuuko/blob/main/yuuko/clockwork/salmon.py
+    pub fn generate_crisp_parameters(&self, rng: &mut impl Rng) -> SalmonConfig {
+        let cohort_abundance: [f64; 4] = {
+            let base = (self.buoyancy / 2.0 + self.pressurization / 2.0) * 10f64.powi(6);
+            [
+                base,
+                base / (rng.gen_range(0.0..1.0) + 1.0),
+                base / (rng.gen_range(0.0..1.0) + 3.0),
+                base / (rng.gen_range(0.0..1.0) + 15.0),
+            ]
+        };
+
+        let maturation_rate: [f64; 4] = [
+            self.chasiness / rng.gen_range(0.0..1.0),
+            self.chasiness * rng.gen_range(0.0..1.0) + 0.2,
+            self.chasiness * (rng.gen_range(0.0..1.0) + 2.0),
+            0.99999999,
+        ];
+
+        let adult_equivalent: [f64; 4] = [
+            rng.sample(LogNormal::new(-self.indulgence, 0.2).unwrap()),
+            rng.sample(LogNormal::new(-self.indulgence + 0.1, 0.2).unwrap()),
+            rng.sample(LogNormal::new(-self.indulgence + 0.3, 0.2).unwrap()),
+            0.99999999,
+        ];
+
+        let exploit_rate_distr = LogNormal::new(-self.anticapitalism, 0.4).unwrap();
+        let exploit_rates: [f64; 4] = [
+            rng.sample(exploit_rate_distr),
+            rng.sample(exploit_rate_distr),
+            rng.sample(exploit_rate_distr),
+            rng.sample(exploit_rate_distr),
+        ];
+
+        let param: f64 = rng.sample(LogNormal::new(-self.moxie + 1.6, 0.3).unwrap());
+        let age_factor: f64 = rng.sample(LogNormal::new(-self.divinity + 1.6, 0.3).unwrap());
+
+        let ev_scalar_distr = LogNormal::new(self.indulgence, 1.0916).unwrap();
+        let ev_scalars: Vec<f64> = std::iter::repeat_with(|| rng.sample(ev_scalar_distr))
+            .take(39)
+            .collect();
+
+        let proportions: [f64; 4] = [
+            rng.sample(LogNormal::new(-(self.watchfulness * 2.0), 0.3).unwrap()),
+            rng.sample(LogNormal::new(-(self.watchfulness * 2.0), 0.3).unwrap()),
+            rng.sample(LogNormal::new(-((self.watchfulness * 2.0).powi(-5)), 0.3).unwrap()),
+            rng.sample(LogNormal::new(-((self.watchfulness * 2.0).powi(-5)), 0.3).unwrap()),
+        ];
+
+        SalmonConfig {
+            stocks: vec![SalmonStock {
+                name: "Salmon Institute T",
+                abbreviation: "SIBR",
+                hatchery_n: "Where the Salmon Are",
+                cohort_abundance,
+                maturation_rate,
+                adult_equivalent,
+                maturation_by_year: std::iter::repeat([
+                    (maturation_rate[0], adult_equivalent[0]),
+                    (maturation_rate[1], adult_equivalent[1]),
+                    (maturation_rate[2], adult_equivalent[2]),
+                    (maturation_rate[3], adult_equivalent[3]),
+                ])
+                .take(39)
+                .collect(),
+                ev_scalars,
+                log_p: ["Log", "Normal", "Indep", "-0.6343", "1.0916", "911"],
+                hatchery_flag: true,
+                msy_esc: 7000,
+                msh_flag: true,
+                idl: 1.0,
+                param,
+                age_factor,
+            }],
+            fisheries: vec![SalmonFishery {
+                name: "Fishy T",
+                proportions,
+                ocean_net: false,
+                exploitations: std::iter::repeat(("SIBR", exploit_rates))
+                    .take(39)
+                    .collect(),
+                policy: std::iter::repeat(1.0).take(39).collect(),
+                terminal: true,
+            }],
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SalmonblallPlayer;
+
+    #[test]
+    fn test_soulscream() {
+        // https://onomancer.sibr.dev/api/generateStats2?name=Hatsune%20Miku
+        let miku = SalmonblallPlayer {
+            pressurization: 0.05102526565489107,
+            divinity: 0.49260097923896856,
+            tragicness: 0.11459214093935316,
+            shakespearianism: 0.9264926244757927,
+            ruthlessness: 0.5720582688050835,
+            chasiness: 0.7760507277652053,
+            indulgence: 1.0279934617333082,
+            anticapitalism: 0.7794113941162841,
+            moxie: 0.6535505979327512,
+            buoyancy: 0.8212275560201918,
+            watchfulness: 0.6983992521888471,
+            soul: 9,
+        };
+
+        assert_eq!(miku.soulscream(), String::from("AUEIXAUEIXAXIEIAXIEIAXEIUHIEIUHIEAHXUAAHXUAAIAIIXIAIIXIXAIIEXAIIEXIIEHIIIEHIIHAUIHHAUIHHXIAUEXIAUEX"));
+
+        // KCBM's Benson Yolk - https://api.sibr.dev/chronicler/v2/entities?type=player&id=82bf8959-480e-435b-9b26-b4738ca141c8&at=2021-12-08T07:43:07.194766Z
+        let benson = SalmonblallPlayer {
+            pressurization: 0.9428976609030266,
+            divinity: 0.390254105871104,
+            tragicness: 0.2787331632251331,
+            shakespearianism: 0.6689638107118578,
+            ruthlessness: 0.9629654468152646,
+            chasiness: 0.5749967575767938,
+            indulgence: 0.8092254212944967,
+            anticapitalism: 0.7456802346202227,
+            moxie: 0.4521547875598889,
+            buoyancy: 0.86486591279949,
+            watchfulness: 0.42204830723953896,
+            soul: 6,
+        };
+
+        assert_eq!(
+            benson.soulscream(),
+            String::from("IOIHIIOIHIIUIAHHUIAHHUIAEEIIAEEIIEIAIIEIAIIEIXOHHIXOHHIAUOOXAUOOXA")
+        );
+    }
+}

--- a/templates/player.html
+++ b/templates/player.html
@@ -7,6 +7,7 @@
 <h1>{{ name }}</h1>
 <ul class="space-x-4 -mt-3 md:-mt-3.5 lg:-mt-4">
   <li class="inline"><a href="https://www.blaseball.com/player/{{ id }}">Player card</a></li>
+  <li class="inline"><a href="/salmon/{{ id }}">Salmon statistics</a></li>
 </ul>
 
 <div class="space-y-4 mt-4">

--- a/templates/salmon.html
+++ b/templates/salmon.html
@@ -1,0 +1,26 @@
+{% import "macros.html" as macros %} {% extends "base.html" %}
+
+<!-- prettier-ignore -->
+{% block title %}{{ name }}{% endblock %}
+
+{% block content %}
+<h1>{{ name }}</h1>
+<ul class="space-x-4 -mt-3 md:-mt-3.5 lg:-mt-4">
+  <li class="inline"><a href="/player/{{ id }}">Blaseball statistics</a></li>
+  <li class="inline"><a href="https://www.blaseball.com/player/{{ id }}">Player card</a></li>
+</ul>
+<div class="space-y-4 mt-4">
+  {% if !salmon.rows.is_empty() %}
+  <h2>Standard Fishing</h2>
+  {% call macros::table(salmon, "sort leading-loose tabular-nums") %}
+  <!-- prettier-ignore -->
+  {% endif %}
+
+  <h2>Glossary</h2>
+  <ul class="mt-0.5 md:mt-1 leading-loose">
+    <li><b>MTUE</b>: Median Time Until Extinction. What's the median length of time that this player's salmon stocks survive for?
+    <li><b>FISH%</b>: Failures In Salmon Harvesting. In what percentage of simulations did this player cause salmon to go extinct?
+    <li><b>ADSP%</b>: Average Decrease in Salmon Populations. Average year-by-year decrease of salmon stocks managed by this player.
+  </ul>
+</div>
+{% endblock %}


### PR DESCRIPTION
support for salmon-related statistics, as calculated by CRiSP.

as of now, the key math based on alisww/yuuko is done, but several key features are missing:
- sending generated CRiSP parameters to WebCRiSP for calculation
- an updating pipeline for player CRiSP stats
- display of CRiSP stats
